### PR TITLE
ignore Mac .DS_Store thumbnail indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 !project.code-workspace
 
 # Please, add your custom content below!
+.DS_Store


### PR DESCRIPTION
# Description

Update .gitignore to ignore `.DS_Store` files (Mac desktop thumbnail index files)