### PR TITLE
Add tip to clear mise cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ A Flask-based web application prototype for the commissioner reporting component
    mise install
    ```
 
+> [!TIP]
+> If `mise` reports an error, you may need to run `mise cache clear`, see
+> [mise issue #2962](https://github.com/jdx/mise/issues/2962mise issue #2962) for more details.
+
 2. **Install project dependencies**
 
    This will install the project dependencies using Poetry and NPM.


### PR DESCRIPTION
# Description

`mise install` appears to sometimes error out if the cache is in a state it doesn't expect.

This adds some instructions on how to deal with it. I'm conscious that adding too many of these could raise the nosie level in the README substantially, but maybe we can deal with that (e.g. remove them) as we get to it.
