### PR TITLE
Stop the build failing on test coverage being too low

### DIFF
--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -59,7 +59,10 @@ jobs:
       - name: "Run test coverage check"
         env:
             SECRET_KEY: "${{ secrets.SECRET_KEY_FOR_TESTS }}"
-            FAIL_IF_UNDER: 80
+            # This is explicitly a prototype, so no need to worry about test
+            # coverage. We'll keep the step for info, as it doesn't take long,
+            # just set the minimum coverage figure to zero:
+            FAIL_IF_UNDER: 0
         run: |
           make test-coverage
       - name: "Save the coverage check result"


### PR DESCRIPTION
This is now (as of #43 ) explicitly and solely a prototype, for rapid iteration and user testing. It will never be production code.

Therefore, we don't need to fail the build if the test coverage is too low. 
